### PR TITLE
add / to beginning of 'pretty_path'

### DIFF
--- a/git.py
+++ b/git.py
@@ -263,7 +263,7 @@ def get_circle_artifacts(owner, repo, ref, GET):
 def _prepare_artifacts(list, base, circle_token):
     '''
     '''
-    artifacts = {relpath(a['pretty_path'], base): '{}?circle-token={}'.format(a['url'], circle_token)
+    artifacts = {relpath('/' + a['pretty_path'], base): '{}?circle-token={}'.format(a['url'], circle_token)
                  for a in list}
 
     if PRECOG_TARBALL_NAME in artifacts:


### PR DESCRIPTION
in the recent circleci change, apparently the format of 'pretty_path' changed, and no longer has a leading '/' which broke the relpath logic, so i'm just prefixing pretty_path with '/' before running relpath on it.